### PR TITLE
changed Hadoop URL in bootstrap.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -42,7 +42,7 @@ master_r_packages = [
 ]
 
 # download link of hadoop.
-hadoop_url = 'http://www.motorlogy.com/apache/hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz'
+hadoop_url = 'http://apache.claz.org/hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz'
 hadoop_dir = 'hadoop-2.6.0'
 
 # customized installation script.


### PR DESCRIPTION
Hi Tianqi,

I tried using this to do some benchmarking of XGBoost, and I run into a problem during the installation phase – the old URL to download hadoop-2.6.0 404s. The new one was found here: http://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-2.6.5/hadoop-2.6.5.tar.gz